### PR TITLE
Add BatteryControl mode

### DIFF
--- a/api/batterymode.go
+++ b/api/batterymode.go
@@ -1,6 +1,6 @@
 package api
 
-// BatteryMode is the home battery operation mode. Valid values are normal, locked and charge
+// BatteryMode is the home battery operation mode. Valid values are normal, hold, charge and control
 type BatteryMode int
 
 //go:generate go tool enumer -type BatteryMode -trimprefix Battery -transform=lower
@@ -9,4 +9,5 @@ const (
 	BatteryNormal
 	BatteryHold
 	BatteryCharge
+	BatteryControl
 )

--- a/api/batterymode_enumer.go
+++ b/api/batterymode_enumer.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _BatteryModeName = "unknownnormalholdcharge"
+const _BatteryModeName = "unknownnormalholdchargecontrol"
 
-var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23}
+var _BatteryModeIndex = [...]uint8{0, 7, 13, 17, 23, 30}
 
-const _BatteryModeLowerName = "unknownnormalholdcharge"
+const _BatteryModeLowerName = "unknownnormalholdchargecontrol"
 
 func (i BatteryMode) String() string {
 	if i < 0 || i >= BatteryMode(len(_BatteryModeIndex)-1) {
@@ -28,9 +28,10 @@ func _BatteryModeNoOp() {
 	_ = x[BatteryNormal-(1)]
 	_ = x[BatteryHold-(2)]
 	_ = x[BatteryCharge-(3)]
+	_ = x[BatteryControl-(4)]
 }
 
-var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge}
+var _BatteryModeValues = []BatteryMode{BatteryUnknown, BatteryNormal, BatteryHold, BatteryCharge, BatteryControl}
 
 var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeName[0:7]:        BatteryUnknown,
@@ -41,6 +42,8 @@ var _BatteryModeNameToValueMap = map[string]BatteryMode{
 	_BatteryModeLowerName[13:17]: BatteryHold,
 	_BatteryModeName[17:23]:      BatteryCharge,
 	_BatteryModeLowerName[17:23]: BatteryCharge,
+	_BatteryModeName[23:30]:      BatteryControl,
+	_BatteryModeLowerName[23:30]: BatteryControl,
 }
 
 var _BatteryModeNames = []string{
@@ -48,6 +51,7 @@ var _BatteryModeNames = []string{
 	_BatteryModeName[7:13],
 	_BatteryModeName[13:17],
 	_BatteryModeName[17:23],
+	_BatteryModeName[23:30],
 }
 
 // BatteryModeString retrieves an enum value from the enum constants string name.

--- a/core/site_battery.go
+++ b/core/site_battery.go
@@ -10,7 +10,11 @@ import (
 )
 
 func batteryModeModified(mode api.BatteryMode) bool {
-	return mode != api.BatteryUnknown && mode != api.BatteryNormal
+	switch mode {
+	case api.BatteryUnknown, api.BatteryNormal, api.BatteryControl:
+		return false
+	}
+	return true
 }
 
 func (site *Site) batteryConfigured() bool {

--- a/core/site_battery_test.go
+++ b/core/site_battery_test.go
@@ -18,14 +18,17 @@ func TestRequiredExternalBatteryMode(t *testing.T) {
 		{api.BatteryUnknown, api.BatteryUnknown, api.BatteryUnknown},
 		{api.BatteryUnknown, api.BatteryNormal, api.BatteryNormal},
 		{api.BatteryUnknown, api.BatteryCharge, api.BatteryCharge},
+		{api.BatteryUnknown, api.BatteryControl, api.BatteryControl},
 
 		{api.BatteryNormal, api.BatteryUnknown, api.BatteryUnknown},
 		{api.BatteryNormal, api.BatteryNormal, api.BatteryUnknown}, // no change required
 		{api.BatteryNormal, api.BatteryCharge, api.BatteryCharge},
+		{api.BatteryNormal, api.BatteryControl, api.BatteryControl},
 
 		{api.BatteryCharge, api.BatteryUnknown, api.BatteryNormal},
 		{api.BatteryCharge, api.BatteryNormal, api.BatteryNormal},
-		{api.BatteryCharge, api.BatteryCharge, api.BatteryUnknown}, // no change required
+		{api.BatteryCharge, api.BatteryCharge, api.BatteryUnknown},   // no change required
+		{api.BatteryControl, api.BatteryControl, api.BatteryUnknown}, // no change required
 	} {
 		t.Logf("%+v", tc)
 
@@ -61,14 +64,17 @@ func TestExternalBatteryModeChange(t *testing.T) {
 		{api.BatteryUnknown, api.BatteryUnknown, api.BatteryNormal},
 		{api.BatteryUnknown, api.BatteryNormal, api.BatteryNormal},
 		{api.BatteryUnknown, api.BatteryCharge, api.BatteryNormal},
+		{api.BatteryUnknown, api.BatteryControl, api.BatteryNormal},
 
 		{api.BatteryNormal, api.BatteryUnknown, api.BatteryNormal},
 		{api.BatteryNormal, api.BatteryNormal, api.BatteryNormal},
 		{api.BatteryNormal, api.BatteryCharge, api.BatteryNormal},
+		{api.BatteryNormal, api.BatteryControl, api.BatteryNormal},
 
 		{api.BatteryCharge, api.BatteryUnknown, api.BatteryNormal},
 		{api.BatteryCharge, api.BatteryNormal, api.BatteryNormal},
 		{api.BatteryCharge, api.BatteryCharge, api.BatteryNormal},
+		{api.BatteryControl, api.BatteryControl, api.BatteryNormal},
 	} {
 		t.Logf("%+v", tc)
 


### PR DESCRIPTION
## Summary
- extend battery mode enum with `BatteryControl`
- regenerate enumerations
- handle `BatteryControl` in site battery logic
- expose new mode to tests
- adjust unit tests for battery mode logic
- document valid battery modes

## Testing
- `go test ./api ./core ./server` *(fails: fetching modules from `storage.googleapis.com` forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68613d9a1b94832196ec9e7a33d0ecfd